### PR TITLE
Avoid duplicate runs of the the Lint action

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -4,6 +4,9 @@ on: [push, pull_request]
 
 jobs:
   lint:
+    if:
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
+      github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Previously we would run twice if a commit was to a branch which was in a pull request.